### PR TITLE
Replace `${variable}` string interpolation with `{$variable}` in `\Suin\Json\{En,De}codingException`

### DIFF
--- a/src/Json/DecodingException.php
+++ b/src/Json/DecodingException.php
@@ -41,7 +41,7 @@ final class DecodingException extends \RuntimeException
         DecodingContext $context
     ) {
         return new self(
-            "Failed to decode JSON: ${errorMessage}",
+            "Failed to decode JSON: {$errorMessage}",
             $errorCode,
             $context
         );

--- a/src/Json/EncodingException.php
+++ b/src/Json/EncodingException.php
@@ -41,7 +41,7 @@ final class EncodingException extends \RuntimeException
         EncodingContext $context
     ) {
         return new self(
-            "Failed to encode JSON: ${errorMessage}",
+            "Failed to encode JSON: {$errorMessage}",
             $errorCode,
             $context
         );


### PR DESCRIPTION
Replaces the deprecated `${variable}` string interpolation with `{$variable}`. See https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation

Changes proposed in this pull request:
- Update `\Suin\Json\DecodingException::create` to use `"Failed to decode JSON: {$errorMessage}",` instead of `"Failed to decode JSON: ${errorMessage}",`
- Update `\Suin\Json\EncodingException::create` to use `"Failed to encode JSON: {$errorMessage}",` instead of `"Failed to encode JSON: ${errorMessage}",`